### PR TITLE
fix vivo or non https web_url

### DIFF
--- a/lib/urlresolver/plugins/vivosx.py
+++ b/lib/urlresolver/plugins/vivosx.py
@@ -33,11 +33,13 @@ class VivosxResolver(UrlResolver):
         web_url = self.get_url(host, media_id)
 
         # get landing page
-        html = self.net.http_GET(web_url, headers={'Referer': web_url}).content
+        resp = self.net.http_GET(web_url, headers={'Referer': web_url})
+        html = resp.content
+        post_url = resp.get_url()
 
         # read POST variables into data
         data = helpers.get_hidden(html)
-        html = self.net.http_POST(web_url, data, headers=({'Referer': web_url, 'X-Requested-With': 'XMLHttpRequest'})).content
+        html = self.net.http_POST(post_url, data, headers=({'Referer': web_url})).content
 
         # search for content tag
         r = re.search(r'class="stream-content" data-url', html)


### PR DESCRIPTION
It seems like vivo switched to https only, but non https links still work. 
If web_url is not a https url then the post url is not  the same as web_url, took care of this case.

BTW. 
I think the site requires TLS1.1 as minimum protocoll version.
So, systems with older python versions might have some troubels, if they don't support this protocoll or if no ssl context is provided.
No troubles with python  2.7.11.