### PR TITLE
rollback pattern

### DIFF
--- a/lib/urlresolver/plugins/mailru.py
+++ b/lib/urlresolver/plugins/mailru.py
@@ -29,7 +29,7 @@ from urlresolver.resolver import UrlResolver, ResolverError
 class MailRuResolver(UrlResolver):
     name = "mail.ru"
     domains = ['mail.ru', 'my.mail.ru', 'm.my.mail.ru', 'videoapi.my.mail.ru', 'api.video.mail.ru']
-    pattern = '(?://|\.)(mail\.ru)/(\w+)/(?:embed/)?(?:([^/]+)/[^.]+/)?(\d+)'
+    pattern = '(?://|\.)(mail\.ru)/(?:\w+/)?(inbox|mail|embed|mailua|list)/(?:([^/]+)/[^.]+/)?(\d+)'
 
     def __init__(self):
         self.net = common.Net()


### PR DESCRIPTION
I had to roll back the pattern to avoid breaking videoapi.my.mail.ru links which I completely overlooked. Added "mailua" and "list" to the previous pattern capture group instead, to match new URL's found by @PBear90.