### PR TITLE
fix short-domains at __top_domain

### DIFF
--- a/lib/urlresolver/hmf.py
+++ b/lib/urlresolver/hmf.py
@@ -114,7 +114,7 @@ class HostedMediaFile:
         elements = urlparse.urlparse(url)
         domain = elements.netloc or elements.path
         domain = domain.split('@')[-1].split(':')[0]
-        regex = "([\w\-]*\.[\w\-]{2,3}(?:\.[\w\-]{2,3})?)$"
+        regex = "(?:www\.)?([\w\-]*\.[\w\-]{2,3}(?:\.[\w\-]{2,3})?)$"
         res = re.search(regex, domain)
         if res: domain = res.group(1)
         domain = domain.lower()


### PR DESCRIPTION
This fix is mainly for short-domains like "ok.ru". The old regex would return "www.ok.ru" the new returns correctly "ok.ru"